### PR TITLE
Change page title from liteapp -> quickapp

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8" />
         <meta name="theme-color" content="#000000">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, minimal-ui">
-        <title>liteapp</title>
+        <title>quickapp</title>
     </head>
     <body>
         <script src="./main.js"></script>


### PR DESCRIPTION
Looks like you missed changing the name in one spot; this resolves that issue
I'm assuming that the page title should still be all lowercase. If not, just tell me and I'll fix that + push another commit.